### PR TITLE
Expose alpha parameter and fix render order

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When installed, import:
 
 **Parameters:**
 
-- ***sets*** - disctionary of sets (required)
+- ***sets*** - dictionary of sets (required)
 - ***out*** - directory to output files, default current directory
 - ***asax*** - if diagram should be plotted as subplot, then provide matplotlib ax here. Default is 'False' which will plot new figure
 - ***ext*** - image extension, default is 'png'.
@@ -41,6 +41,7 @@ When installed, import:
 - ***legend_cols*** - number of legend columns, default is 2.
 - ***column_spacing*** - column spacing in legend, default is 4.
 - ***edge_color*** - edge colors, default is 'black'.
+- ***alpha*** - fill opacity of the sets, default is 0.3.
 
 
 Check "Examples.ipynb" https://github.com/timyerg/venny4py/blob/main/Examples.ipynb to see some examples.

--- a/src/venny4py/venny4py.py
+++ b/src/venny4py/venny4py.py
@@ -96,8 +96,10 @@ def venny4py(
         ae = [225, 225, 315, 315] #angles
 
         for i, s in enumerate(sets):
-            ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i], 
+            ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i],
                                   angle=ae[i], alpha=alpha))
+
+        for i, s in enumerate(sets):
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc='None',
                                   angle=ae[i], ec=ec, lw=lw))
 
@@ -126,8 +128,10 @@ def venny4py(
         cs = 1 #columns spacing
 
         for i, s in enumerate(sets):
-            ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i], 
+            ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i],
                                   angle=0, alpha=alpha))
+
+        for i, s in enumerate(sets):
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc='None',
                                   angle=0, ec=ec, lw=lw))
 
@@ -155,8 +159,10 @@ def venny4py(
         ye = [45, 45] #y coordinats
 
         for i, s in enumerate(sets):
-            ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i], 
+            ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i],
                                   angle=0, alpha=alpha))
+
+        for i, s in enumerate(sets):
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc='None',
                                   angle=0, ec=ec, lw=lw))
 

--- a/src/venny4py/venny4py.py
+++ b/src/venny4py/venny4py.py
@@ -54,7 +54,8 @@ def venny4py(
         font_size=None,
         legend_cols=2,
         column_spacing=4,
-        edge_color='black'
+        edge_color='black',
+        alpha=0.3
 ):
     if len(sets) < 2 or len(sets) > 4:
         raise ValueError('Number of sets must be 2, 3 or 4')
@@ -96,7 +97,7 @@ def venny4py(
 
         for i, s in enumerate(sets):
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i], 
-                                  angle=ae[i], alpha=.3))
+                                  angle=ae[i], alpha=alpha))
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc='None',
                                   angle=ae[i], ec=ec, lw=lw))
 
@@ -126,7 +127,7 @@ def venny4py(
 
         for i, s in enumerate(sets):
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i], 
-                                  angle=0, alpha=.3))
+                                  angle=0, alpha=alpha))
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc='None',
                                   angle=0, ec=ec, lw=lw))
 
@@ -155,7 +156,7 @@ def venny4py(
 
         for i, s in enumerate(sets):
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc=ce[i], 
-                                  angle=0, alpha=.3))
+                                  angle=0, alpha=alpha))
             ax.add_artist(Ellipse(xy=(xe[i], ye[i]), width=ew, height=eh, fc='None',
                                   angle=0, ec=ec, lw=lw))
 
@@ -173,7 +174,7 @@ def venny4py(
                     transform=ax.transData)
                 
     #legend
-    handles = [mpatches.Patch(color=ce[i], label=l, alpha=.3) for i, l in enumerate(sets)]
+    handles = [mpatches.Patch(color=ce[i], label=l, alpha=alpha) for i, l in enumerate(sets)]
     ax.legend(labels=sets, handles=handles, fontsize=fs*1.1, frameon=False, 
               bbox_to_anchor=(.5, .99), bbox_transform=ax.transAxes, loc=9, 
               handlelength=1.5, ncol=nc, columnspacing=cs, handletextpad=.5)


### PR DESCRIPTION
Thanks for this neat and lightweight project for creating  4-set Venns in Python.

This PR makes two small improvements:

## 1. Expose `alpha` as a parameter

The fill opacity was previously hardcoded to 0.3. This PR exposes it as a user-configurable parameter while keeping the default value (0.3) unchanged.

```python
venny4py(sets=sets, alpha=0.1)
```

<img width="466" height="463" alt="Venn_4" src="https://github.com/user-attachments/assets/4f7341f3-f4da-4b4c-b2b3-8f52e69f9ba8" />

## 2. Fix the render order

Ellipse fills and edges were drawn together per set previously. As a result,  later fills could cover earlier edges. 

This PR solves in two steps:
1. Draw all fills first
2. Draw all edges afterward

### Previous
<img width="466" height="463" alt="Venn_4_before" src="https://github.com/user-attachments/assets/bfbf7fa1-8e94-48bf-bcfd-6244b1699a7a" />
 
### After
<img width="466" height="463" alt="Venn_4_after" src="https://github.com/user-attachments/assets/4191ff46-6023-4907-badd-585a7981c66a" />


